### PR TITLE
Add support for the fun-asr-nano onnx model to manyspeech

### DIFF
--- a/src/ManySpeech/AliParaformerAsr/Model/OfflineInputEntity.cs
+++ b/src/ManySpeech/AliParaformerAsr/Model/OfflineInputEntity.cs
@@ -6,6 +6,8 @@ namespace ManySpeech.AliParaformerAsr.Model
     {
         public float[]? Speech { get; set; }
         public int SpeechLength { get; set; }
-        public List<int[]>? Hotwords { get; set; } = new List<int[]>();
+        public List<string>? Hotwords { get; set; } = new List<string>();
+        public string? Language { get; set; }
+        public string? Region { get; set; }
     }
 }

--- a/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoCtc.cs
+++ b/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoCtc.cs
@@ -44,15 +44,15 @@ namespace ManySpeech.AliParaformerAsr
             {
                 Tensor<float>? logitsTensor = decoderOutputEntity.LogitsTensor;
                 string method = _offlineModel.Method;
-                // 2. 根据解码策略执行对应逻辑
+                // Execute the corresponding logic according to the decoding strategy
                 if (string.Equals(method, "greedy", StringComparison.OrdinalIgnoreCase))
                 {
-                    // 调用对齐原逻辑的贪心搜索
+                    // Invoke greedy search aligned with the original logic
                     ExecuteGreedySearch(logitsTensor, tokenIdsList, timestampsList);
                 }
                 else if (string.Equals(method, "beam", StringComparison.OrdinalIgnoreCase))
                 {
-                    // 调用束搜索
+                    // Invoke beam search
                     ExecuteBeamSearch(logitsTensor, tokenIdsList, timestampsList, _offlineModel.BeamWidth);
                 }
                 else
@@ -75,7 +75,7 @@ namespace ManySpeech.AliParaformerAsr
         }
 
         /// <summary>
-        /// 执行贪心搜索解码
+        /// Executes greedy search decoding
         /// </summary>
         private void ExecuteGreedySearch(Tensor<float>? logitsTensor,
                                                List<List<int>> tokenIdsList,
@@ -84,15 +84,15 @@ namespace ManySpeech.AliParaformerAsr
             if (logitsTensor == null) return;
             for (int batchIndex = 0; batchIndex < logitsTensor.Dimensions[0]; batchIndex++)
             {
-                // 存储单个批次的Token ID序列
+                // Store the Token ID sequence for a single batch
                 int[] batchTokenIds = new int[logitsTensor.Dimensions[1]];
-                // 存储单个批次的Token时间戳
+                // Store the Token timestamps for a single batch
                 List<int[]> batchTokenTimestamps = new List<int[]>();
                 for (int sequenceStep = 0; sequenceStep < logitsTensor.Dimensions[1]; sequenceStep++)
                 {
-                    // 当前序列位置的最优Token ID
+                    // The optimal Token ID at the current sequence position
                     int bestTokenId = 0;
-                    // 逐一遍历Token，保留概率更大的Token ID
+                    // Iterate through Tokens one by one and retain Token IDs with higher probabilities
                     for (int tokenIndex = 1; tokenIndex < logitsTensor.Dimensions[2]; tokenIndex++)
                     {
                         bestTokenId = logitsTensor[batchIndex, sequenceStep, bestTokenId] > logitsTensor[batchIndex, sequenceStep, tokenIndex]
@@ -104,15 +104,15 @@ namespace ManySpeech.AliParaformerAsr
                     batchTokenTimestamps.Add(new int[] { 0, 0 });
                 }
 
-                tokenIdsList.Add(RemoveDuplicatesAndBlank(batchTokenIds));  
+                tokenIdsList.Add(RemoveDuplicatesAndBlank(batchTokenIds));
                 timestampsList.Add(batchTokenTimestamps);
             }
         }
 
         /// <summary>
-        /// 执行束搜索解码（核心逻辑：维护Top-N候选序列，选整体最优）
+        /// Executes beam search decoding (maintains Top-N candidate sequences and selects the globally optimal one)
         /// </summary>
-        /// <param name="beamWidth">束宽度（越大精度越高，性能越低）</param>
+        /// <param name="beamWidth">Beam width (higher = better accuracy, lower performance)</param>
         private void ExecuteBeamSearch(Tensor<float> logitsTensor,
                                              List<List<int>> tokenIdsList,
                                              List<List<int[]>> timestampsList,
@@ -120,48 +120,48 @@ namespace ManySpeech.AliParaformerAsr
         {
             for (int batchIdx = 0; batchIdx < logitsTensor.Dimensions[0]; batchIdx++)
             {
-                // 初始化束：保存(序列, 累计概率)，初始为空序列
+                // Initialize beam: stores (sequence, cumulative probability), starting with empty sequence
                 var beam = new List<(List<int> sequence, float totalProb)> { (new List<int>(), 0f) };
 
                 for (int seqIdx = 0; seqIdx < logitsTensor.Dimensions[1]; seqIdx++)
                 {
                     var candidates = new List<(List<int> sequence, float totalProb)>();
 
-                    // 遍历当前束中的所有候选序列
+                    // Iterate all candidate sequences in the current beam
                     foreach (var (currentSeq, currentProb) in beam)
                     {
-                        // 为当前序列的下一个位置生成所有可能的Token及概率
+                        // Generate all possible Tokens and their probabilities for the next position of the current sequence
                         var tokenProbs = new List<(int tokenId, float prob)>();
                         for (int tokenIdx = 0; tokenIdx < logitsTensor.Dimensions[2]; tokenIdx++)
                         {
                             tokenProbs.Add((tokenIdx, logitsTensor[batchIdx, seqIdx, tokenIdx]));
                         }
 
-                        // 按概率排序，取Top-BeamWidth个Token
+                        // Sort by probability and take top BeamWidth Tokens
                         var topTokens = tokenProbs.OrderByDescending(t => t.prob).Take(beamWidth);
                         foreach (var (tokenId, prob) in topTokens)
                         {
-                            // 生成新序列并累加概率（这里用加法，实际可改用对数概率避免下溢）
+                            // Create new sequence and accumulate probability (addition used here; log probability can be used to avoid underflow in practice)
                             var newSeq = new List<int>(currentSeq) { tokenId };
                             float newProb = currentProb + prob;
                             candidates.Add((newSeq, newProb));
                         }
                     }
 
-                    // 从所有候选中选Top-BeamWidth个，更新束
+                    // Select top BeamWidth candidates and update the beam
                     beam = candidates.OrderByDescending(c => c.totalProb).Take(beamWidth).ToList();
                 }
 
-                // 取束中概率最大的序列作为最终结果
+                // Select the sequence with the highest probability as the final result
                 var bestSequence = beam.OrderByDescending(b => b.totalProb).First().sequence;
-                // 补全序列长度（与贪心搜索结果维度对齐）
+                // Pad sequence length to match dimensions with greedy search results
                 while (bestSequence.Count < logitsTensor.Dimensions[1])
                 {
-                    bestSequence.Add(0); // 补零
+                    bestSequence.Add(0); // Pad with zero
                 }
 
                 tokenIdsList.Add(RemoveDuplicatesAndBlank(bestSequence.ToArray()));
-                // 初始化时间戳
+                // Initialize timestamps
                 timestampsList.Add(Enumerable.Repeat(new int[] { 0, 0 }, logitsTensor.Dimensions[1]).ToList());
             }
         }

--- a/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoCtc.cs
+++ b/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoCtc.cs
@@ -1,0 +1,312 @@
+﻿// See https://github.com/manyeyes for more information
+// Copyright (c)  2026 by manyeyes
+using ManySpeech.AliParaformerAsr.Model;
+using ManySpeech.AliParaformerAsr.Utils;
+using ManySpeech.SeqUnit;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+
+namespace ManySpeech.AliParaformerAsr
+{
+    internal class OfflineProjOfFunAsrNanoCtc : IOfflineProj, IDisposable
+    {
+        // To detect redundant calls
+        private bool _disposed;
+
+        private InferenceSession? _encoderSession;
+        private InferenceSession? _decoderSession;
+        private OfflineModel _offlineModel;
+        private ITokenizer _tokenizer;
+        private int _sampleRate = 16000;
+        private int _speechLength = 30;
+        private bool _isResizeAudioDuration = false;
+        private bool _isPaddingSpeech = false;
+
+        public OfflineProjOfFunAsrNanoCtc(OfflineModel offlineModel)
+        {
+            _offlineModel = offlineModel;
+            _encoderSession = offlineModel.EncoderSession;
+            _decoderSession = offlineModel.DecoderSession;
+            _tokenizer = AutoTokenizer.Create(type: TokenizerType.Tiktoken, vocabFilePath: offlineModel.TokensFilePath, encodingName: "multilingual");
+        }
+        public OfflineModel OfflineModel { get => _offlineModel; set => _offlineModel = value; }
+        public ITokenizer Tokenizer { get => _tokenizer; set => _tokenizer = value; }
+        public int SampleRate { get => _sampleRate; set => _sampleRate = value; }
+        public int SpeechLength { get => _speechLength; set => _speechLength = value; }
+        public bool IsPaddingSpeech { get => _isPaddingSpeech; set => _isPaddingSpeech = value; }
+        public bool IsResizeAudioDuration { get => _isResizeAudioDuration; set => _isResizeAudioDuration = value; }
+
+        public void Infer(List<OfflineInputEntity> modelInputs, List<List<int>> tokenIdsList, List<List<int[]>> timestampsList, List<string>? languages = null, List<string>? regions = null)
+        {
+            EncoderOutputEntity encoderOutputEntity = EncoderProj(modelInputs);
+            DecoderOutputEntity decoderOutputEntity = DecoderProj(encoderOutputEntity);
+            if (decoderOutputEntity != null)
+            {
+                Tensor<float>? logitsTensor = decoderOutputEntity.LogitsTensor;
+                string method = _offlineModel.Method;
+                // 2. 根据解码策略执行对应逻辑
+                if (string.Equals(method, "greedy", StringComparison.OrdinalIgnoreCase))
+                {
+                    // 调用对齐原逻辑的贪心搜索
+                    ExecuteGreedySearch(logitsTensor, tokenIdsList, timestampsList);
+                }
+                else if (string.Equals(method, "beam", StringComparison.OrdinalIgnoreCase))
+                {
+                    // 调用束搜索
+                    ExecuteBeamSearch(logitsTensor, tokenIdsList, timestampsList, _offlineModel.BeamWidth);
+                }
+                else
+                {
+                    throw new ArgumentException($"Unsupported decode method: {method}, only 'greedy' or 'beam' is allowed");
+                }
+                //if (modelOutputEntity.CifPeak != null)
+                //{
+                //    timestampsList = new List<List<int[]>>();
+                //    Tensor<float> cifPeak = modelOutputEntity.CifPeak;
+                //    for (int i = 0; i < cifPeak.Dimensions[0]; i++)
+                //    {
+                //        float[] usCifPeak = new float[cifPeak.Dimensions[1]];
+                //        Array.Copy(cifPeak.ToArray(), i * usCifPeak.Length, usCifPeak, 0, usCifPeak.Length);
+                //        List<int[]> timestamps = ComputeHelper.TimestampLfr6(usCifPeak, tokenIdsList[i].ToArray());
+                //        timestampsList.Add(timestamps);
+                //    }
+                //}
+            }
+        }
+
+        /// <summary>
+        /// 执行贪心搜索解码
+        /// </summary>
+        private void ExecuteGreedySearch(Tensor<float>? logitsTensor,
+                                               List<List<int>> tokenIdsList,
+                                               List<List<int[]>> timestampsList)
+        {
+            if (logitsTensor == null) return;
+            for (int batchIndex = 0; batchIndex < logitsTensor.Dimensions[0]; batchIndex++)
+            {
+                // 存储单个批次的Token ID序列
+                int[] batchTokenIds = new int[logitsTensor.Dimensions[1]];
+                // 存储单个批次的Token时间戳
+                List<int[]> batchTokenTimestamps = new List<int[]>();
+                for (int sequenceStep = 0; sequenceStep < logitsTensor.Dimensions[1]; sequenceStep++)
+                {
+                    // 当前序列位置的最优Token ID
+                    int bestTokenId = 0;
+                    // 逐一遍历Token，保留概率更大的Token ID
+                    for (int tokenIndex = 1; tokenIndex < logitsTensor.Dimensions[2]; tokenIndex++)
+                    {
+                        bestTokenId = logitsTensor[batchIndex, sequenceStep, bestTokenId] > logitsTensor[batchIndex, sequenceStep, tokenIndex]
+                            ? bestTokenId
+                            : tokenIndex;
+                    }
+
+                    batchTokenIds[sequenceStep] = bestTokenId;
+                    batchTokenTimestamps.Add(new int[] { 0, 0 });
+                }
+
+                tokenIdsList.Add(RemoveDuplicatesAndBlank(batchTokenIds));  
+                timestampsList.Add(batchTokenTimestamps);
+            }
+        }
+
+        /// <summary>
+        /// 执行束搜索解码（核心逻辑：维护Top-N候选序列，选整体最优）
+        /// </summary>
+        /// <param name="beamWidth">束宽度（越大精度越高，性能越低）</param>
+        private void ExecuteBeamSearch(Tensor<float> logitsTensor,
+                                             List<List<int>> tokenIdsList,
+                                             List<List<int[]>> timestampsList,
+                                             int beamWidth)
+        {
+            for (int batchIdx = 0; batchIdx < logitsTensor.Dimensions[0]; batchIdx++)
+            {
+                // 初始化束：保存(序列, 累计概率)，初始为空序列
+                var beam = new List<(List<int> sequence, float totalProb)> { (new List<int>(), 0f) };
+
+                for (int seqIdx = 0; seqIdx < logitsTensor.Dimensions[1]; seqIdx++)
+                {
+                    var candidates = new List<(List<int> sequence, float totalProb)>();
+
+                    // 遍历当前束中的所有候选序列
+                    foreach (var (currentSeq, currentProb) in beam)
+                    {
+                        // 为当前序列的下一个位置生成所有可能的Token及概率
+                        var tokenProbs = new List<(int tokenId, float prob)>();
+                        for (int tokenIdx = 0; tokenIdx < logitsTensor.Dimensions[2]; tokenIdx++)
+                        {
+                            tokenProbs.Add((tokenIdx, logitsTensor[batchIdx, seqIdx, tokenIdx]));
+                        }
+
+                        // 按概率排序，取Top-BeamWidth个Token
+                        var topTokens = tokenProbs.OrderByDescending(t => t.prob).Take(beamWidth);
+                        foreach (var (tokenId, prob) in topTokens)
+                        {
+                            // 生成新序列并累加概率（这里用加法，实际可改用对数概率避免下溢）
+                            var newSeq = new List<int>(currentSeq) { tokenId };
+                            float newProb = currentProb + prob;
+                            candidates.Add((newSeq, newProb));
+                        }
+                    }
+
+                    // 从所有候选中选Top-BeamWidth个，更新束
+                    beam = candidates.OrderByDescending(c => c.totalProb).Take(beamWidth).ToList();
+                }
+
+                // 取束中概率最大的序列作为最终结果
+                var bestSequence = beam.OrderByDescending(b => b.totalProb).First().sequence;
+                // 补全序列长度（与贪心搜索结果维度对齐）
+                while (bestSequence.Count < logitsTensor.Dimensions[1])
+                {
+                    bestSequence.Add(0); // 补零
+                }
+
+                tokenIdsList.Add(RemoveDuplicatesAndBlank(bestSequence.ToArray()));
+                // 初始化时间戳
+                timestampsList.Add(Enumerable.Repeat(new int[] { 0, 0 }, logitsTensor.Dimensions[1]).ToList());
+            }
+        }
+
+        /// <summary>
+        /// Removes duplicate tokens and blank tokens from the sequence
+        /// </summary>
+        /// <param name="yseq">Original token sequence</param>
+        /// <param name="blank_id">The identifier for blank token (default: 0)</param>
+        /// <returns>List of tokens with duplicates and blank tokens removed</returns>
+        public List<int> RemoveDuplicatesAndBlank(int[] yseq, int blank_id = 0)
+        {
+            // Null and empty check to avoid exceptions caused by null array
+            if (yseq == null || yseq.Length == 0)
+            {
+                return new List<int>();
+            }
+
+            int prev_token = -1;
+            List<int> decoded_tokens = new List<int>();
+
+            // Iterate through the token sequence to remove duplicates and blank tokens
+            foreach (int token in yseq)
+            {
+                // Only keep: current token != previous token AND current token != blank token
+                if (token != prev_token && token != blank_id)
+                {
+                    decoded_tokens.Add(token);
+                }
+                prev_token = token;
+            }
+
+            return decoded_tokens;
+        }
+
+        private EncoderOutputEntity EncoderProj(List<OfflineInputEntity> modelInputs)
+        {
+            int batchSize = modelInputs.Count;
+            float[] padSequence = PadHelper.PadSequence(modelInputs);
+            var inputMeta = _encoderSession?.InputMetadata;
+            var container = new List<NamedOnnxValue>();
+            foreach (var name in inputMeta.Keys)
+            {
+                if (name == "speech")
+                {
+                    int[] dim = new int[] { batchSize, padSequence.Length / 560 / batchSize, 560 };
+                    var tensor = new DenseTensor<float>(padSequence, dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<float>(name, tensor));
+                }
+                if (name == "speech_lengths")
+                {
+                    int[] dim = new int[] { batchSize };
+                    Int64[] speech_lengths = new Int64[batchSize];
+                    for (int i = 0; i < batchSize; i++)
+                    {
+                        speech_lengths[i] = padSequence.Length / 560 / batchSize;
+                    }
+                    var tensor = new DenseTensor<Int64>(speech_lengths, dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<Int64>(name, tensor));
+                }
+            }
+            EncoderOutputEntity encoderOutputEntity = new EncoderOutputEntity();
+            try
+            {
+                IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results = _encoderSession.Run(container);
+
+                if (results != null)
+                {
+                    var resultsArray = results.ToArray();
+                    encoderOutputEntity.EncOut = resultsArray[0].AsTensor<float>();
+                    encoderOutputEntity.EncOutLens = resultsArray[1].AsEnumerable<Int64>().ToArray();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("EncoderProj failed", ex);
+            }
+            return encoderOutputEntity;
+        }
+        private DecoderOutputEntity DecoderProj(EncoderOutputEntity encoderOutputEntity)
+        {
+            int batchSize = encoderOutputEntity.EncOut.Dimensions[0];
+            var inputMeta = _decoderSession?.InputMetadata;
+            var container = new List<NamedOnnxValue>();
+            foreach (var name in inputMeta.Keys)
+            {
+                if (name == "encoder_out")
+                {
+                    int[] dim = new int[] { batchSize, encoderOutputEntity.EncOut.ToArray().Length / 512 / batchSize, 512 };
+                    var tensor = new DenseTensor<float>(encoderOutputEntity.EncOut.ToArray(), dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<float>(name, tensor));
+                }
+                if (name == "encoder_out_lens")
+                {
+                    int[] dim = new int[] { batchSize };
+                    Int64[] encoder_out_lens = new Int64[batchSize];
+                    for (int i = 0; i < batchSize; i++)
+                    {
+                        encoder_out_lens[i] = encoderOutputEntity.EncOut.ToArray().Length / 512 / batchSize;
+                    }
+                    var tensor = new DenseTensor<Int64>(encoder_out_lens, dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<Int64>(name, tensor));
+                }
+            }
+            DecoderOutputEntity decoderOutputEntity = new DecoderOutputEntity();
+            try
+            {
+                IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results = _decoderSession.Run(container);
+
+                if (results != null)
+                {
+                    var resultsArray = results.ToArray();
+                    decoderOutputEntity.LogitsTensor = resultsArray[0].AsTensor<float>();
+                    decoderOutputEntity.DecOutLens = resultsArray[1].AsEnumerable<Int64>().ToArray();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("DecoderProj failed", ex);
+            }
+            return decoderOutputEntity;
+        }
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    if (_offlineModel != null)
+                    {
+                        _offlineModel.Dispose();
+                    }
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+        ~OfflineProjOfFunAsrNanoCtc()
+        {
+            Dispose(_disposed);
+        }
+    }
+}

--- a/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoLLM.cs
+++ b/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoLLM.cs
@@ -1,0 +1,506 @@
+﻿// See https://github.com/manyeyes for more information
+// Copyright (c)  2026 by manyeyes
+using ManySpeech.AliParaformerAsr.Model;
+using ManySpeech.AliParaformerAsr.Utils;
+using ManySpeech.SeqUnit;
+using Microsoft.ML.OnnxRuntime;
+using Microsoft.ML.OnnxRuntime.Tensors;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ManySpeech.AliParaformerAsr
+{
+    internal class OfflineProjOfFunAsrNanoLLM : IOfflineProj, IDisposable
+    {
+        private bool _disposed;
+
+        private readonly InferenceSession _encoderSession;
+        private readonly InferenceSession _adaptorSession;
+        private readonly InferenceSession _decoderSession;
+        private readonly InferenceSession _embedSession;
+        private readonly OfflineModel _offlineModel;
+        private readonly ITokenizer _tokenizer;
+        private int _sampleRate = 16000;
+        private int _speechLength = 30;
+        private bool _isResizeAudioDuration = true;
+        private bool _isPaddingSpeech = false;
+        private bool _useITN = false;
+
+        // 模型参数
+        private const int _hiddenDim = 1024;
+        private const int _numLayers = 28;
+        private const int _numHeads = 8;
+        private const int _headDim = 128;
+        private const int _vocabSize = 151936;
+        private const int _maxNewTokens = 200;
+        private const float _repeatPenalty = 1.0f;
+        private static readonly HashSet<int> _stopTokens = new HashSet<int> { 151643, 151645 };
+
+        // 预计算提示词嵌入
+        private readonly float[] _systemEmbed;
+        private readonly float[] _userPrefixEmbed;
+        private readonly float[] _assistantPrefixEmbed;
+
+        public OfflineProjOfFunAsrNanoLLM(OfflineModel offlineModel)
+        {
+            _offlineModel = offlineModel;
+            _encoderSession = offlineModel.EncoderSession ?? throw new ArgumentNullException(nameof(offlineModel.EncoderSession));
+            _decoderSession = offlineModel.DecoderSession ?? throw new ArgumentNullException(nameof(offlineModel.DecoderSession));
+            _embedSession = offlineModel.EmbedSession ?? throw new ArgumentNullException(nameof(offlineModel.EmbedSession));
+            _adaptorSession = offlineModel.AdaptorSession ?? null;
+            _useITN = offlineModel.UseITN;
+
+            // 初始化 tokenizer
+            _tokenizer = AutoTokenizer.Create(type: TokenizerType.Tiktoken,
+                                              vocabFilePath: offlineModel.TokensFilePath,
+                                              encodingName: "qwen3");
+
+            // 预计算系统提示嵌入
+            _systemEmbed = EmbedPrompt("<|im_start|>system\n\nYou are a helpful assistant.<|im_end|>\n");
+            _userPrefixEmbed = EmbedPrompt("<|im_start|>user\n");
+            _assistantPrefixEmbed = EmbedPrompt("<|im_end|>\n<|im_start|>assistant\n");
+        }
+
+        public OfflineModel OfflineModel => _offlineModel;
+        public ITokenizer Tokenizer => _tokenizer;
+
+        public int SampleRate { get => _sampleRate; set => _sampleRate = value; }
+        public int SpeechLength { get => _speechLength; set => _speechLength = value; }
+        public bool IsPaddingSpeech { get => _isPaddingSpeech; set => _isPaddingSpeech = value; }
+        public bool IsResizeAudioDuration { get => _isResizeAudioDuration; set => _isResizeAudioDuration = value; }
+
+        /// <summary>
+        /// 将文本转换为嵌入（扁平化数组，形状 [1, seq_len, hidden_dim]）
+        /// </summary>
+        private float[] EmbedPrompt(string text)
+        {
+            var tokenIds = _tokenizer.Encode(text, isAllowSpecial: true);
+            return EmbedProj(tokenIds);
+        }
+
+        private float[] EmbedProj(int[] tokenIds)
+        {
+            var inputTensor = new DenseTensor<long>(new[] { 1, tokenIds.Length });
+            for (int i = 0; i < tokenIds.Length; i++)
+                inputTensor[0, i] = tokenIds[i];
+
+            string embedInputName = _embedSession.InputMetadata.Keys.First();
+            var inputs = new List<NamedOnnxValue>
+            {
+                NamedOnnxValue.CreateFromTensor(embedInputName, inputTensor)
+            };
+
+            using (var results = _embedSession.Run(inputs))
+            {
+                var outputTensor = results.First().AsTensor<float>();
+                return outputTensor.ToArray(); // [1, seq_len, hidden_dim]
+            }
+        }
+
+        /// <summary>
+        /// 编码音频特征为嵌入（支持 batch）
+        /// </summary>
+        private EncoderOutputEntity EncoderProj(List<OfflineInputEntity> modelInputs)
+        {
+            int batchSize = modelInputs.Count;
+            float[] padSequence = PadHelper.PadSequence(modelInputs);
+            var inputMeta = _encoderSession?.InputMetadata;
+            var container = new List<NamedOnnxValue>();
+            foreach (var name in inputMeta.Keys)
+            {
+                if (name == "speech")
+                {
+                    // 计算 shape: [batch, time, 560]
+                    int time = padSequence.Length / 560 / batchSize;
+                    int[] dim = new int[] { batchSize, time, 560 };
+                    var tensor = new DenseTensor<float>(padSequence, dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<float>(name, tensor));
+                }
+                if (name == "speech_lengths")
+                {
+                    int[] dim = new int[] { batchSize };
+                    Int64[] speech_lengths = new Int64[batchSize];
+                    for (int i = 0; i < batchSize; i++)
+                    {
+                        speech_lengths[i] = padSequence.Length / 560 / batchSize;
+                    }
+                    var tensor = new DenseTensor<Int64>(speech_lengths, dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<Int64>(name, tensor));
+                }
+            }
+            EncoderOutputEntity encoderOutputEntity = new EncoderOutputEntity();
+            try
+            {
+                IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results = _encoderSession.Run(container);
+
+                if (results != null)
+                {
+                    var resultsArray = results.ToArray();
+                    encoderOutputEntity.EncOut = resultsArray[0].AsTensor<float>();
+                    encoderOutputEntity.EncOutLens = resultsArray[1].AsEnumerable<Int64>().ToArray();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("EncoderProj failed", ex);
+            }
+            return encoderOutputEntity;
+        }
+
+        private EncoderOutputEntity AdaptorProj(EncoderOutputEntity encoderOutputEntity)
+        {
+            var inputMeta = _adaptorSession?.InputMetadata;
+            var container = new List<NamedOnnxValue>();
+            foreach (var name in inputMeta.Keys)
+            {
+                if (name == "encoder_out")
+                {
+                    int[] dim = encoderOutputEntity.EncOut.Dimensions.ToArray();
+                    var tensor = new DenseTensor<float>(encoderOutputEntity.EncOut.ToArray(), dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<float>(name, tensor));
+                }
+                if (name == "encoder_out_lens")
+                {
+                    int[] dim = new int[] { encoderOutputEntity.EncOutLens.Length };
+                    Int64[] encoder_out_lens = encoderOutputEntity.EncOutLens;
+                    var tensor = new DenseTensor<Int64>(encoder_out_lens, dim, false);
+                    container.Add(NamedOnnxValue.CreateFromTensor<Int64>(name, tensor));
+                }
+            }
+            try
+            {
+                IDisposableReadOnlyCollection<DisposableNamedOnnxValue> results = _adaptorSession.Run(container);
+
+                if (results != null)
+                {
+                    var resultsArray = results.ToArray();
+                    encoderOutputEntity.EncOut = resultsArray[0].AsTensor<float>();
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("AdaptorProj failed", ex);
+            }
+            return encoderOutputEntity;
+        }
+
+        /// <summary>
+        /// 批量拼接嵌入，并返回 padding 后的结果
+        /// </summary>
+        private (float[] initHidden, int[] initLens) ConcatBatchEmbeddings(
+            List<float[]> batchAudioEmbed,
+            float[] systemEmbed,
+            float[] userPrefixEmbed,
+            float[] promptEmbed,
+            float[] assistantPrefixEmbed)
+        {
+            int batchSize = batchAudioEmbed.Count;
+            int systemLen = systemEmbed.Length / _hiddenDim;
+            int userLen = userPrefixEmbed.Length / _hiddenDim;
+            int promptLen = promptEmbed.Length / _hiddenDim;
+            int assistantLen = assistantPrefixEmbed.Length / _hiddenDim;
+
+            int fixedLen = systemLen + userLen + promptLen + assistantLen;
+            int[] audioLens = batchAudioEmbed.Select(emb => emb.Length / _hiddenDim).ToArray();
+            int[] totalLens = audioLens.Select(l => fixedLen + l).ToArray();
+            int maxTotalLen = totalLens.Max();
+
+            var result = new float[batchSize * maxTotalLen * _hiddenDim];
+            for (int b = 0; b < batchSize; b++)
+            {
+                float[] audioEmb = batchAudioEmbed[b];
+                int audioLen = audioLens[b];
+
+                int offset = 0;
+                // system
+                Array.Copy(systemEmbed, 0, result, b * maxTotalLen * _hiddenDim + offset, systemEmbed.Length);
+                offset += systemEmbed.Length;
+                // user
+                Array.Copy(userPrefixEmbed, 0, result, b * maxTotalLen * _hiddenDim + offset, userPrefixEmbed.Length);
+                offset += userPrefixEmbed.Length;
+                // prompt
+                Array.Copy(promptEmbed, 0, result, b * maxTotalLen * _hiddenDim + offset, promptEmbed.Length);
+                offset += promptEmbed.Length;
+                // audio
+                Array.Copy(audioEmb, 0, result, b * maxTotalLen * _hiddenDim + offset, audioEmb.Length);
+                offset += audioEmb.Length;
+                // assistant
+                Array.Copy(assistantPrefixEmbed, 0, result, b * maxTotalLen * _hiddenDim + offset, assistantPrefixEmbed.Length);
+            }
+
+            return (result, totalLens);
+        }
+
+        /// <summary>
+        /// 批量自回归解码
+        /// </summary>
+        private List<List<int>> DecodeBatch(float[] initHidden, int[] initLens)
+        {
+            int batchSize = initLens.Length;
+            int maxSeqLen = initHidden.Length / batchSize / _hiddenDim;
+
+            var outputMetadata = _decoderSession.OutputMetadata;
+            var outputNames = outputMetadata.Keys.ToList();
+            int expectedOutputs = _numLayers * 2 + 2;
+            if (outputNames.Count != expectedOutputs)
+                throw new InvalidOperationException($"Expected {expectedOutputs} outputs, but found {outputNames.Count}");
+
+            var keyOutputIndices = Enumerable.Range(0, _numLayers).ToList();
+            var valueOutputIndices = Enumerable.Range(_numLayers, _numLayers).ToList();
+            int logitsIndex = _numLayers * 2;
+            int kvSeqLenIndex = _numLayers * 2 + 1;
+
+            var inputs = new Dictionary<string, NamedOnnxValue>();
+
+            var inputMetadata = _decoderSession.InputMetadata;
+            for (int i = 0; i < _numLayers; i++)
+            {
+                string keyName = $"in_key_{i}";
+                string valueName = $"in_value_{i}";
+                var keyShape = inputMetadata[keyName].Dimensions;
+                var valueShape = inputMetadata[valueName].Dimensions;
+
+                var keyDims = keyShape.Select(d => d == -1 ? 0 : d).ToArray();
+                keyDims[0] = batchSize;
+                var valueDims = valueShape.Select(d => d == -1 ? 0 : d).ToArray();
+                valueDims[0] = batchSize;
+
+                var keyTensor = new DenseTensor<float>(keyDims);
+                var valueTensor = new DenseTensor<float>(valueDims);
+                inputs[keyName] = NamedOnnxValue.CreateFromTensor(keyName, keyTensor);
+                inputs[valueName] = NamedOnnxValue.CreateFromTensor(valueName, valueTensor);
+            }
+
+            var hiddenTensor = new DenseTensor<float>(new[] { batchSize, maxSeqLen, _hiddenDim });
+            for (int i = 0; i < initHidden.Length; i++)
+                hiddenTensor.Buffer.Span[i] = initHidden[i];
+            inputs["hidden_states"] = NamedOnnxValue.CreateFromTensor("hidden_states", hiddenTensor);
+
+            var historyLenTensor = new DenseTensor<long>(new[] { 1 });
+            for (int b = 0; b < 1; b++)
+                historyLenTensor[b] = 0;
+            inputs["history_len"] = NamedOnnxValue.CreateFromTensor("history_len", historyLenTensor);
+
+            var idsLenTensor = new DenseTensor<long>(new[] { 1 });
+            for (int b = 0; b < 1; b++)
+                idsLenTensor[b] = initLens[b];
+            inputs["ids_len"] = NamedOnnxValue.CreateFromTensor("ids_len", idsLenTensor);
+
+            var attnMaskTensor = new DenseTensor<sbyte>(new[] { 1 });
+            for (int b = 0; b < 1; b++)
+                attnMaskTensor[b] = 1;
+            inputs["attention_mask"] = NamedOnnxValue.CreateFromTensor("attention_mask", attnMaskTensor);
+
+            var generated = new List<List<int>>();
+            for (int b = 0; b < batchSize; b++)
+                generated.Add(new List<int>());
+            var penalty = new float[batchSize][];
+            for (int b = 0; b < batchSize; b++)
+            {
+                penalty[b] = new float[_vocabSize];
+                for (int i = 0; i < _vocabSize; i++)
+                    penalty[b][i] = 1.0f;
+            }
+            try
+            {
+                bool[] finished = new bool[batchSize];
+                int step = 0;
+                while (step < _maxNewTokens && finished.Any(f => !f))
+                {
+                    using (var results = _decoderSession.Run(inputs.Values))
+                    {
+                        var resultsArray = results.ToArray();
+
+                        var logitsTensor = resultsArray[logitsIndex].AsTensor<float>();
+                        var kvSeqLenTensor = resultsArray[kvSeqLenIndex].AsTensor<long>();
+
+                        int[] nextTokens = new int[batchSize];
+                        for (int b = 0; b < batchSize; b++)
+                        {
+                            if (finished[b])
+                            {
+                                nextTokens[b] = -1;
+                                continue;
+                            }
+
+                            float[] logits = new float[_vocabSize];
+                            for (int i = 0; i < _vocabSize; i++)
+                                logits[i] = logitsTensor[b, i];
+
+                            int nextToken = 0;
+                            float maxLogit = logits[0] * penalty[b][0];
+                            for (int i = 1; i < _vocabSize; i++)
+                            {
+                                float val = logits[i] * penalty[b][i];
+                                if (val > maxLogit)
+                                {
+                                    maxLogit = val;
+                                    nextToken = i;
+                                }
+                            }
+
+                            if (_stopTokens.Contains(nextToken))
+                            {
+                                finished[b] = true;
+                                nextTokens[b] = -1;
+                            }
+                            else
+                            {
+                                nextTokens[b] = nextToken;
+                                generated[b].Add(nextToken);
+                                penalty[b][nextToken] *= _repeatPenalty;
+                            }
+                        }
+
+                        if (finished.All(f => f))
+                            break;
+
+                        var newHiddenTensor = new DenseTensor<float>(new[] { batchSize, 1, _hiddenDim });
+                        for (int b = 0; b < batchSize; b++)
+                        {
+                            if (finished[b])
+                                continue;
+                            int tokenId = nextTokens[b];
+                            var tokenEmbed = EmbedProj(new[] { tokenId });
+                            for (int i = 0; i < _hiddenDim; i++)
+                                newHiddenTensor[b, 0, i] = tokenEmbed[i];
+                        }
+                        inputs["hidden_states"] = NamedOnnxValue.CreateFromTensor("hidden_states", newHiddenTensor);
+
+                        var newHistoryLenTensor = new DenseTensor<long>(new[] { 1 });
+                        for (int b = 0; b < 1; b++)
+                            newHistoryLenTensor[b] = kvSeqLenTensor[b];
+                        inputs["history_len"] = NamedOnnxValue.CreateFromTensor("history_len", newHistoryLenTensor);
+
+                        var newIdsLenTensor = new DenseTensor<long>(new[] { 1 });
+                        for (int b = 0; b < 1; b++)
+                            newIdsLenTensor[b] = finished[b] ? 0 : 1;
+                        inputs["ids_len"] = NamedOnnxValue.CreateFromTensor("ids_len", newIdsLenTensor);
+
+                        var newAttnMaskTensor = new DenseTensor<sbyte>(new[] { 1 });
+                        for (int b = 0; b < 1; b++)
+                            newAttnMaskTensor[b] = 0;
+                        inputs["attention_mask"] = NamedOnnxValue.CreateFromTensor("attention_mask", newAttnMaskTensor);
+
+                        // 更新 KV 缓存（使用原方法：ToArray + 新张量）
+                        for (int i = 0; i < _numLayers; i++)
+                        {
+                            var keyTensor = resultsArray[i].AsTensor<float>();
+                            int[] keyDim = keyTensor.Dimensions.ToArray();
+                            var keyCopy = new DenseTensor<float>(keyTensor.ToArray(), keyDim, false);
+                            inputs[$"in_key_{i}"] = NamedOnnxValue.CreateFromTensor($"in_key_{i}", keyCopy);
+
+                            var valueTensor = resultsArray[i + _numLayers].AsTensor<float>();
+                            int[] valueDim = valueTensor.Dimensions.ToArray();
+                            var valueCopy = new DenseTensor<float>(valueTensor.ToArray(), valueDim, false);
+                            inputs[$"in_value_{i}"] = NamedOnnxValue.CreateFromTensor($"in_value_{i}", valueCopy);
+                        }
+                    }
+                    step++;
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new Exception("DecodeBatch failed", ex);
+            }
+            return generated;
+        }
+
+        public List<int> RemoveDuplicatesAndBlank(int[] yseq, int blank_id = 0)
+        {
+            if (yseq == null || yseq.Length == 0)
+                return new List<int>();
+
+            int prev_token = -1;
+            var decoded = new List<int>();
+            foreach (int token in yseq)
+            {
+                if (token != prev_token && token != blank_id)
+                    decoded.Add(token);
+                prev_token = token;
+            }
+            return decoded;
+        }
+
+        public void Infer(List<OfflineInputEntity> modelInputs, List<List<int>> tokenIdsList,
+                          List<List<int[]>> timestampsList, List<string>? languages = null,
+                          List<string>? regions = null)
+        {
+            if (modelInputs == null || modelInputs.Count == 0)
+                return;
+
+            string[] hotwords = new string[] { "开放时间" };
+            string hotwordsStr = string.Join(",", hotwords);
+            string lang = "中文";
+            string prompt = "请结合上下文信息，更加准确地完成语音转写任务。如果没有相关信息，我们会留空。\n\n\n**上下文信息：**\n\n\n";
+            if (!string.IsNullOrWhiteSpace(hotwordsStr))
+                prompt += $"热词列表：[{hotwordsStr}]\n";
+            prompt += $"语音转写成：{lang}";
+            if (!_useITN)
+                prompt += "，不进行文本规整";
+            prompt += "：";
+
+            var promptEmbed = EmbedPrompt(prompt);
+
+            var encoderOutput = EncoderProj(modelInputs);
+            if (_adaptorSession != null)
+            {
+                encoderOutput = AdaptorProj(encoderOutput);
+            }
+            var audioEmbedTensor = encoderOutput.EncOut;
+            int batchSize = modelInputs.Count;
+            int audioTimeDim = audioEmbedTensor.Dimensions[1];
+            int hiddenDim = audioEmbedTensor.Dimensions[2];
+
+            List<float[]> batchAudioEmbed = new List<float[]>();
+            for (int b = 0; b < batchSize; b++)
+            {
+                float[] audioEmb = new float[audioTimeDim * hiddenDim];
+                for (int t = 0; t < audioTimeDim; t++)
+                    for (int d = 0; d < hiddenDim; d++)
+                        audioEmb[t * hiddenDim + d] = audioEmbedTensor[b, t, d];
+                batchAudioEmbed.Add(audioEmb);
+            }
+
+            var (initHidden, initLens) = ConcatBatchEmbeddings(
+                batchAudioEmbed,
+                _systemEmbed,
+                _userPrefixEmbed,
+                promptEmbed,
+                _assistantPrefixEmbed
+            );
+
+            var batchGenerated = DecodeBatch(initHidden, initLens);
+
+            for (int b = 0; b < batchSize; b++)
+            {
+                tokenIdsList.Add(batchGenerated[b]);
+                timestampsList.Add(new List<int[]>());
+            }
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    _offlineModel?.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~OfflineProjOfFunAsrNanoLLM()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoLLM.cs
+++ b/src/ManySpeech/AliParaformerAsr/OfflineProjOfFunAsrNanoLLM.cs
@@ -424,15 +424,64 @@ namespace ManySpeech.AliParaformerAsr
         }
 
         public void Infer(List<OfflineInputEntity> modelInputs, List<List<int>> tokenIdsList,
-                          List<List<int[]>> timestampsList, List<string>? languages = null,
-                          List<string>? regions = null)
+                  List<List<int[]>> timestampsList, List<string>? languages = null,
+                  List<string>? regions = null)
         {
             if (modelInputs == null || modelInputs.Count == 0)
                 return;
 
+            // 保存每个输入对应的结果，按原始索引存放
+            var allTokenIds = new List<List<int>>(new List<int>[modelInputs.Count]);
+            var allTimestamps = new List<List<int[]>>(new List<int[]>[modelInputs.Count]);
+
+            // 为每个输入添加索引，便于分组后还原顺序
+            var indexedInputs = modelInputs.Select((input, idx) => new { input, idx }).ToList();
+
+            // 按 Language 分组（null 也作为一组）
+            var groups = indexedInputs.GroupBy(x => x.input.Language);
+
+            foreach (var group in groups)
+            {
+                var groupInputs = group.Select(x => x.input).ToList();
+                var groupIndices = group.Select(x => x.idx).ToList();
+
+                // 处理当前分组
+                ProcessBatch(groupInputs, out var batchTokenIds, out var batchTimestamps);
+
+                // 将结果存回对应索引位置
+                for (int i = 0; i < groupIndices.Count; i++)
+                {
+                    int origIndex = groupIndices[i];
+                    allTokenIds[origIndex] = batchTokenIds[i];
+                    allTimestamps[origIndex] = batchTimestamps[i];
+                }
+            }
+            tokenIdsList.Clear();
+            timestampsList.Clear();
+            tokenIdsList.AddRange(allTokenIds);
+            timestampsList.AddRange(allTimestamps);
+        }
+
+        // 处理一个 batch
+        private void ProcessBatch(List<OfflineInputEntity> batchInputs,
+                                  out List<List<int>> batchTokenIds,
+                                  out List<List<int[]>> batchTimestamps)
+        {
+            // 1. 热词
             string[] hotwords = new string[] { "开放时间" };
+            List<string>? hotwordList = batchInputs.SelectMany(x => x.Hotwords).ToList();
+            if (hotwordList != null && hotwordList.Count > 0)
+            {
+                hotwords = hotwordList.ToArray();
+            }
+            else if (_offlineModel.Hotwords?.Length > 0)
+            {
+                hotwords = _offlineModel.Hotwords;
+            }
+
             string hotwordsStr = string.Join(",", hotwords);
-            string lang = "中文";
+            // 根据分组语言动态设置 lang
+            string lang = batchInputs.FirstOrDefault()?.Language ?? "中文";
             string prompt = "请结合上下文信息，更加准确地完成语音转写任务。如果没有相关信息，我们会留空。\n\n\n**上下文信息：**\n\n\n";
             if (!string.IsNullOrWhiteSpace(hotwordsStr))
                 prompt += $"热词列表：[{hotwordsStr}]\n";
@@ -443,13 +492,14 @@ namespace ManySpeech.AliParaformerAsr
 
             var promptEmbed = EmbedPrompt(prompt);
 
-            var encoderOutput = EncoderProj(modelInputs);
+            // 2. 编码
+            var encoderOutput = EncoderProj(batchInputs);
             if (_adaptorSession != null)
             {
                 encoderOutput = AdaptorProj(encoderOutput);
             }
             var audioEmbedTensor = encoderOutput.EncOut;
-            int batchSize = modelInputs.Count;
+            int batchSize = batchInputs.Count;
             int audioTimeDim = audioEmbedTensor.Dimensions[1];
             int hiddenDim = audioEmbedTensor.Dimensions[2];
 
@@ -473,10 +523,13 @@ namespace ManySpeech.AliParaformerAsr
 
             var batchGenerated = DecodeBatch(initHidden, initLens);
 
+            // 输出
+            batchTokenIds = new List<List<int>>(batchSize);
+            batchTimestamps = new List<List<int[]>>(batchSize);
             for (int b = 0; b < batchSize; b++)
             {
-                tokenIdsList.Add(batchGenerated[b]);
-                timestampsList.Add(new List<int[]>());
+                batchTokenIds.Add(batchGenerated[b]);
+                batchTimestamps.Add(new List<int[]>());
             }
         }
 

--- a/src/ManySpeech/AliParaformerAsr/OfflineProjOfSeacoParaformer.cs
+++ b/src/ManySpeech/AliParaformerAsr/OfflineProjOfSeacoParaformer.cs
@@ -21,6 +21,8 @@ namespace ManySpeech.AliParaformerAsr
         private int _speechLength = 30;
         private bool _isResizeAudioDuration = false;
         private bool _isPaddingSpeech = false;
+        private string[] _hotwords;
+        private List<int[]>? _hotwordIds = new List<int[]>();
 
         public OfflineProjOfSeacoParaformer(OfflineModel offlineModel)
         {
@@ -28,6 +30,23 @@ namespace ManySpeech.AliParaformerAsr
             _modelSession = offlineModel.ModelSession;
             _embedSession = offlineModel.EmbedSession;
             _tokenizer = AutoTokenizer.Create(type: TokenizerType.Textoken, vocabFilePath: offlineModel.TokensFilePath);
+            _hotwords = new string[] { "魔搭" };
+            if (_offlineModel.Hotwords?.Length > 0)
+            {
+                _hotwords = _offlineModel.Hotwords;
+            }
+            if (_hotwords.Length > 0)
+            {
+                foreach (string word in _hotwords)
+                {
+                    int[]? ids = _tokenizer.Encode(word);
+                    if (ids != null)
+                    {
+                        _hotwordIds.Add(ids);
+                    }
+                }
+                _hotwordIds.Add(new int[] { OfflineModel.Sos_eos_id });
+            }
         }
         public OfflineModel OfflineModel { get => _offlineModel; set => _offlineModel = value; }
         public ITokenizer Tokenizer { get => _tokenizer; set => _tokenizer = value; }
@@ -222,28 +241,28 @@ namespace ManySpeech.AliParaformerAsr
         {
             int batchSize = modelInputs.Count;
             Tensor<float>? hotwordsEmbed = null;
-            List<int[]>? hotwordIds = modelInputs.SelectMany(x => x.Hotwords).ToList();
-            if (hotwordIds != null && hotwordIds?.Count > 0)
+
+            var hotwordList = modelInputs.SelectMany(x => x.Hotwords).ToList();
+            string[]? hotwords = hotwordList.Count > 0 ? hotwordList.ToArray() : null;
+            List<int[]>? hotwordIds = new List<int[]>();
+            if (hotwords != null && hotwords.Length > 0)
             {
-                hotwordsEmbed = EmbedProj(hotwordIds);
+                foreach (string word in hotwords)
+                {
+                    int[]? ids = _tokenizer.Encode(word);
+                    if (ids != null)
+                    {
+                        hotwordIds.Add(ids);
+                    }
+                }
+                hotwordIds.Add(new int[] { OfflineModel.Sos_eos_id });
             }
             else
             {
-                string[] hotwords = _offlineModel.Hotwords;
-                if (hotwords.Length>0)
-                {
-                    foreach (string word in hotwords)
-                    {
-                        int[]? ids=_tokenizer.Encode(word);
-                        if (ids != null)
-                        {
-                            hotwordIds.Add(ids);
-                        }
-                    }
-                    hotwordIds.Add(new int[] { OfflineModel.Sos_eos_id });
-                }
-                hotwordsEmbed = EmbedProj(hotwordIds);
+                hotwordIds = _hotwordIds;
             }
+            hotwordsEmbed = EmbedProj(hotwordIds);
+
             float[] padSequence = PadHelper.PadSequence(modelInputs);
             var inputMeta = _modelSession.InputMetadata;
             var container = new List<NamedOnnxValue>();

--- a/src/ManySpeech/AliParaformerAsr/OfflineStream.cs
+++ b/src/ManySpeech/AliParaformerAsr/OfflineStream.cs
@@ -16,7 +16,7 @@ namespace ManySpeech.AliParaformerAsr
         private List<int> _tokenIds = new List<int>();
         private List<string>? _tokens = new List<string>();
         private List<int[]>? _timestamps = new List<int[]>();
-        private List<int[]>? _hotwords = new List<int[]>();
+        private List<string>? _hotwords = new List<string>();
 
         private static object obj = new object();
         internal OfflineStream(IOfflineProj offlineProj)
@@ -35,7 +35,7 @@ namespace ManySpeech.AliParaformerAsr
         public List<int> TokenIds { get => _tokenIds; set => _tokenIds = value; }
         public List<string>? Tokens { get => _tokens; set => _tokens = value; }
         public List<int[]> Timestamps { get => _timestamps; set => _timestamps = value; }
-        public List<int[]>? Hotwords { get => _hotwords; set => _hotwords = value; }
+        public List<string>? Hotwords { get => _hotwords; set => _hotwords = value; }
         public string? Region { get => _region; set => _region = value; }
         public string? Language { get => _language; set => _language = value; }
 
@@ -58,6 +58,8 @@ namespace ManySpeech.AliParaformerAsr
                 OfflineInputEntity.Speech = featuresTemp;
                 OfflineInputEntity.SpeechLength = featuresTemp.Length;
                 OfflineInputEntity.Hotwords = Hotwords;
+                OfflineInputEntity.Language= Language;
+                OfflineInputEntity.Region = Region;
             }
         }
         public OfflineInputEntity GetDecodeChunk()
@@ -67,6 +69,8 @@ namespace ManySpeech.AliParaformerAsr
                 if (OfflineInputEntity.Speech != null && OfflineInputEntity.SpeechLength > 0)
                 {
                     OfflineInputEntity.Hotwords = Hotwords;
+                    OfflineInputEntity.Language = Language;
+                    OfflineInputEntity.Region = Region;
                 }
                 return OfflineInputEntity;
             }


### PR DESCRIPTION
# Fun-ASR-Nano-2512
Open-source model from [Fun-ASR](https://github.com/FunAudioLLM/Fun-ASR)

## Fun-ASR-Nano ONNX model download links
Speech recognition supports Chinese, English, and Japanese. Chinese includes support for 7 dialects (Wu, Cantonese, Min, Hakka, Gan, Xiang, Jin) and 26 regional accents (Henan, Shanxi, Hubei, Sichuan, Chongqing, Yunnan, Guizhou, Guangdong, Guangxi and more than 20 other regions). English and Japanese cover multiple regional accents. Additional features include lyric recognition and rap speech recognition.
### with LLM decode
- [Fun-ASR-Nano-2512-LLM-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-Nano-2512-LLM-onnx)
- [Fun-ASR-Nano-2512-LLM-int8-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-Nano-2512-LLM-int8-onnx)
- [Fun-ASR-Nano-2512-LLM-split-adaptor-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-Nano-2512-LLM-split-adaptor-onnx)
- [Fun-ASR-Nano-2512-LLM-split-adaptor-int8-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-Nano-2512-LLM-split-adaptor-int8-onnx)
### with CTC decode
- [Fun-ASR-Nano-2512-CTC-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-Nano-2512-CTC-onnx)
- [Fun-ASR-Nano-2512-CTC-int8-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-Nano-2512-CTC-int8-onnx)

## Fun-ASR-MLT-Nano ONNX model download links
Speech recognition supports Chinese, English, Cantonese, Japanese, Korean, Vietnamese, Indonesian, Thai, Malay, Filipino, Arabic, Hindi, Bulgarian, Croatian, Czech, Danish, Dutch, Estonian, Finnish, Greek, Hungarian, Irish, Latvian, Lithuanian, Maltese, Polish, Portuguese, Romanian, Slovak, Slovenian, Swedish, and 31 languages in total.
### with LLM decode
- [Fun-ASR-MLT-Nano-2512-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-MLT-Nano-2512-onnx)
- [Fun-ASR-MLT-Nano-2512-int8-onnx](https://modelscope.cn/models/manyeyes/Fun-ASR-MLT-Nano-2512-int8-onnx)
